### PR TITLE
Only announce changed values

### DIFF
--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -90,8 +90,17 @@ Template.blackboard.events
      event.stopPropagation() # keep .bb-editable from being processed!
      edit = $(event.currentTarget).closest('*[data-bbedit]').attr('data-bbedit')
      [type, id, rest...] = edit.split('/')
-     # XXX confirm delete?
-     processBlackboardEdit[type]?(null, id, rest...) # process delete
+     message = "Are you sure you want to delete "
+     if (type is'tags') or (rest[0] is 'title')
+       message += "this #{pretty_collection(type)}?"
+     else
+       message += "the #{rest[0]} of this #{pretty_collection(type)}?"
+     confirmationDialog
+       ok_button: 'Yes, delete it'
+       no_button: 'No, cancel'
+       message: message
+       ok: ->
+         processBlackboardEdit[type]?(null, id, rest...) # process delete
   "click .bb-canEdit .bb-editable": (event, template) ->
      edit = $(event.currentTarget).attr('data-bbedit')
      # note that we rely on 'blur' on old field (which triggers ok or cancel)

--- a/client/header.coffee
+++ b/client/header.coffee
@@ -168,6 +168,29 @@ ensureNick = (cb=(->)) ->
   else
     changeNick cb
 
+############## confirmation dialog ########################
+Template.header_confirmmodal.confirmModalVisible = ->
+  !!(Session.get 'confirmModalVisible')
+Template.header_confirmmodal.preserve ['#confirmModal']
+Template.header_confirmmodal_contents.created = ->
+  this.afterFirstRender = =>
+    $('#confirmModal').modal show: true
+Template.header_confirmmodal_contents.rendered = ->
+  this.afterFirstRender?()
+  this.afterFirstRender = undefined
+Template.header_confirmmodal_contents.events
+  "click .bb-confirm-ok": (event, template) ->
+     Template.header_confirmmodal_contents.cancel = false # do the thing!
+     $('#confirmModal').modal 'hide'
+
+confirmationDialog = (options) ->
+  $('#confirmModal').one 'hide', ->
+    Session.set 'confirmModalVisible', undefined
+    options.ok?() unless Template.header_confirmmodal_contents.cancel
+  # store away options before making dialog visible
+  Template.header_confirmmodal_contents.options = -> options
+  Template.header_confirmmodal_contents.cancel = true
+  Session.set 'confirmModalVisible', (options or Object.create(null))
 
 ############## operation log in header ####################
 Template.header_lastupdates.lastupdates = ->

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -54,8 +54,9 @@ BlackboardRouter = Backbone.Router.extend
     Session.set "currentPage", page
     Session.set "type", type
     Session.set "id", id
-    # cancel modal if it was active
+    # cancel modals if they were active
     $('#nickPickModal').modal 'hide'
+    $('#confirmModal').modal 'hide'
 
   urlFor: (type,id) ->
     "/#{type}/#{id}"

--- a/header.html
+++ b/header.html
@@ -184,3 +184,26 @@
       </button>
     </div>
 </template>
+
+<template name="header_confirmmodal">
+  <div class="modal hide" id="confirmModal">
+    {{! only insert contents if visible; this lets us manage
+        dependencies so we're not updating invisible content }}
+    {{#if confirmModalVisible}}{{> header_confirmmodal_contents }}{{/if}}
+  </div>
+</template>
+
+<template name="header_confirmmodal_contents">
+  <div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal"
+            aria-hidden="true">&times;</button>
+    <h3>Are you sure?</h3>
+  </div>
+  <div class="modal-body">
+    <p>{{options.message}}</p>
+  </div>
+  <div class="modal-footer">
+    <button class="btn bb-confirm-ok">{{options.ok_button}}</button>
+    <button class="btn btn-primary" data-dismiss="modal" aria-hidden="true">{{options.no_button}}</button>
+  </div>
+</template>

--- a/page.html
+++ b/page.html
@@ -9,6 +9,7 @@
     </div>
   </div>
   {{> header_nickmodal}}
+  {{> header_confirmmodal}}
 </body>
 
 <template name="page">


### PR DESCRIPTION
We were performing update+oplogs on changes even when the value in the text box wasn't being modified, which is spammy.  After this patch, we do a .getOne(id) and compare values before submitting the update.
