### PR TITLE
Only perform updates and oplogs if a value is changing

### DIFF
--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -229,6 +229,7 @@ canonical = (s) ->
     now = UTCNow()
 
     # Only perform the rename and oplog if the name is changing
+    # XXX: This is racy with updates to findOne().name.
     if collection(type).findOne(args.id).name is args.name
       return false
 
@@ -480,6 +481,7 @@ canonical = (s) ->
       now = UTCNow()
 
       # Only perform the update and oplog if the answer is changing
+      # XXX: This is racy with updates to findOne().answer.
       if Puzzles.findOne(id).answer is answer
         return false
 


### PR DESCRIPTION
We were performing update+oplogs on changes even when the value in the text box wasn't being modified, which is spammy. After this patch, we do a .findOne(id) and compare values before submitting the update.
