### PR TITLE
Fix tab completion by moving whos_here() out of helpers

### DIFF
--- a/client/chat.coffee
+++ b/client/chat.coffee
@@ -171,11 +171,12 @@ Template.messages.created = ->
 
 Template.chat_header.helpers
   room_name: -> prettyRoomName()
-  whos_here: ->
-    roomName = Session.get('type') + '/' + Session.get('id')
-    return model.Presence.find {room_name: roomName}, {sort:["nick"]}
 
 # Utility functions
+
+whos_here = ->
+  roomName = Session.get('type') + '/' + Session.get('id')
+  return model.Presence.find {room_name: roomName}, {sort:["nick"]}
 
 regex_escape = (s) -> s.replace /[$-\/?[-^{|}]/g, '\\$&'
 
@@ -406,11 +407,10 @@ Template.messages_input.events
     # tab completion
     if event.which is 9 # tab
       event.preventDefault() # prevent tabbing away from input field
-      whos_here = Template.chat_header.whos_here().fetch()
       $message = $ event.currentTarget
       message = $message.val()
       if message
-        for present in whos_here
+        for present in whos_here().fetch()
           n = model.Nicks.findOne(canon: present.nick)
           realname = if n then model.getTag(n, 'Real Name')
           re = new RegExp "^#{message}", "i"


### PR DESCRIPTION
deb7f72cb6 ("Use Template#helpers method to define helpers.") moved
some methods away from being on the Template object to being Spacebars
helpers.  But Template.messages_input.events was making a call to
Template.chat_header.whos_here() directly, and that doesn't work
after the refactor.

There wasn't any need for the cross-template method call anyway,
so just make whos_here() a utility function of chat.coffee to fix.
