### PR TITLE
Make blackboard and chat more usable on mobile

### DIFF
--- a/blackboard.less
+++ b/blackboard.less
@@ -669,7 +669,7 @@ html.fullHeight {
   }
 }
 
-@media (min-width: 480px) and (max-width: 979px) {
+@media (min-width: 481px) and (max-width: 979px) {
   /* re-fix the chat footer to the bottom */
   .bb-chat-footer.navbar-fixed-bottom {
     position: fixed;
@@ -685,5 +685,21 @@ html.fullHeight {
   /* Remove padding above jumbotron */
   body {
     padding-top: 0;
+  }
+  #bb-body {
+    .bb-blackboard-h1 { display: none; }
+    .bb-lastchat, .bb-lastupdate {
+      padding-left: 0px;
+      padding-right: 50px;
+      font-size: 75%;
+      & > .left { display: none; }
+    } 
+    .table-condensed {
+      th, td {
+        padding: 2px;
+        font-size: 75%;
+        line-height: initial;
+      }
+    }
   }
 }

--- a/chat.less
+++ b/chat.less
@@ -162,17 +162,45 @@
 .bb-chat-presence .near:before { .glyphicon-white; }
 
 @media (max-width: 480px) {
+  body {
+    padding-left: 0px;
+    padding-right: 0px;
+    background: white;
+  }
+  .navbar-fixed-top, .navbar-fixed-bottom {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
   .bb-chat-messages {
     .media {
+      margin-top: 0px;
+      margin-bottom: 0px;
       /* hide chat bubble arrows when display gets too narrow */
       &:before, &:after { display: none; }
       .timestamp { float: right; /* still */ }
-      .media-object.pull-left { display: none; }
+      .media-object.pull-left { float: left; /* still */ margin: 0px; }
+      .img-rounded {
+                border-radius: 0px;
+           -moz-border-radius: 0px;
+        -webkit-border-radius: 0px;
+      }
     }
+    .media + .media.bb-message-followup { margin-top: -4px; }
     .bb-message-action, .bb-message-system { padding-left: 6px; }
-    .bb-message-body { min-height: 0; }
+    .bb-message-last-read { margin-left: 0px; margin-right: 0px; }
+    .bb-message-body {
+      /* min-height: 0; */
+              border-radius: 0px;
+         -moz-border-radius: 0px;
+      -webkit-border-radius: 0px;
+    }
   }
 }
+/*
+@media (max-width: 432px) {
+  .bb-chat-messages .media-object.pull-left { display: none; }
+} 
+*/ 
 /* hide messages from bot if bot is muted */
 html.bb-nobot .bb-is-bot { display: none; }
 

--- a/header.less
+++ b/header.less
@@ -1,6 +1,3 @@
-#bb-body .bb-topbar {
-  min-width: 465px;
-}
 #bb-body .navbar-inverse .navbar-inner {
   background: url('/img/irongrip.png');
   color: #c4c4c4;

--- a/page.html
+++ b/page.html
@@ -1,6 +1,6 @@
 <head>
   <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-  <meta name="viewport" content="width=600, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="shortcut icon" href="##ROOT_URL_PATH_PREFIX##/img/codex_icon-64x64.ico" />
   <link rel="apple-touch-icon" href="##ROOT_URL_PATH_PREFIX##/img/codex_icon-128x128.png" />
   <title>Blackboard</title>


### PR DESCRIPTION
This doesn't fix the puzzle pages, but it makes the chat the right width for the screen, fits the blackboard on screen, and makes sure some useful info is visible in the navbar.
FIxes #155