### PR TITLE
Fix emoji check.

### DIFF
--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -37,7 +37,7 @@ Meteor.startup ->
     return ctx.getImageData(x, y, 1, 1)
   reddot = checkEmoji '\uD83D\uDD34', 16, 16
   dancing = checkEmoji '\uD83D\uDD7A', 12, 16 # unicode 9.0
-  if reddot[0] > reddot[1] and dancing[0] > 0
+  if reddot.data[0] > reddot.data[1] and dancing.data[0] + dancing.data[1] + dancing.data[2] > 0
     console.log 'has unicode 9 color emojis'
     document.body.classList.add 'has-emojis'
 


### PR DESCRIPTION
The return value of getImageData is an instance of ImageData (https://developer.mozilla.org/en-US/docs/Web/API/ImageData) which doesn't have an array access operation, at least in the standard. You have to access its 'data' member. As a result the old check was comparing undefined to undefined. Also, I don't know what color your man_dancing is, but on Windows he's blue, so comparing the red component didn't work. (Even better would probably be to search for a non-black pixel in a range in case a particular platform happened to have a black pixel there.)
Fixes #319