### PR TITLE
Eliminate abbreviated "who's working" list

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -263,15 +263,7 @@
       </td>
     {{#unless canEdit}}
     <td class="puzzle-working">
-      <div class="{{#if lotsOfPeople whos_working.count}}bb-lots{{/if}}">
-      <span class="bb-short">
-      {{ whos_working.count }} people
-      ({{local_working}}<i class="icon-map-marker"></i>)
-      </span>
-      <span class="bb-long">
       {{#each whos_working}}{{> nick_presence }} {{/each}}
-      </span>
-      </div>
     </td>
     <td class="puzzle-update">
       {{#if round.solved}}solved {{pretty_ts timestamp=round.solved style="brief duration"}}
@@ -395,15 +387,7 @@
     </td>
     {{#unless canEdit}}
     <td class="puzzle-working">
-      <div class="{{#if lotsOfPeople whos_working.count}}bb-lots{{/if}}">
-      <span class="bb-short">
-      {{ whos_working.count }} people
-      ({{local_working}}<i class="icon-map-marker"></i>)
-      </span>
-      <span class="bb-long">
       {{#each whos_working}}{{> nick_presence }} {{/each}}
-      </span>
-      </div>
     </td>
     <td class="puzzle-update">
       {{#if puzzle.solved}}solved {{pretty_ts timestamp=puzzle.solved style="brief duration"}}

--- a/blackboard.less
+++ b/blackboard.less
@@ -404,14 +404,6 @@ body.has-emojis {
 
     .puzzle-working {
       .background { color: #ccc; }
-      .bb-lots {
-         .bb-short { display: block; }
-         .bb-long { display: none; }
-      }
-      &, &:hover .bb-lots {
-         .bb-short { display: none; }
-         .bb-long { display: block; }
-      }
     }
     td.puzzle-update {
       font-size: 85%;

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -351,11 +351,6 @@ Template.blackboard_round.helpers
     return model.Presence.find
       room_name: ("rounds/"+this.round?._id)
     , sort: ["nick"]
-  local_working: ->
-    count = 0
-    model.Presence.find(room_name: ("rounds/"+this.round?._id)).forEach (p) ->
-      count++ if share.isNickNear(p.nick)
-    count
   compactMode: compactMode
   nCols: nCols
   stuck: share.model.isStuck 
@@ -367,11 +362,6 @@ Template.blackboard_puzzle.helpers
     return model.Presence.find
       room_name: ("puzzles/"+this.puzzle?._id)
     , sort: ["nick"]
-  local_working: ->
-    count = 0
-    model.Presence.find(room_name: ("puzzles/"+this.puzzle?._id)).forEach (p) ->
-      count++ if share.isNickNear(p.nick)
-    count
   compactMode: compactMode
   nCols: nCols
   stuck: share.model.isStuck


### PR DESCRIPTION
Always show the whole list, now that it uses mini-gravatars instead of nicks. The alternative was that it would reflow, potentially moving it out from uder the cursor and flickering. Fixes #264.