### PR TITLE
Make team name a public setting

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -79,7 +79,7 @@
 </div>
     <h1 align="center" class="bb-blackboard-h1">
       <span class="bb-no-wrap">
-      <span class="bb-hide-when-narrower">Codex</span></span> <span class="bb-hide-when-narrow">Puzzle </span><span class="bb-no-wrap">Blackboard
+      <span class="bb-hide-when-narrower">{{teamName}}</span></span> <span class="bb-hide-when-narrow">Puzzle </span><span class="bb-no-wrap">Blackboard
       </span>
     </h1>
   <table class="table table-bordered table-condensed bb-puzzle">

--- a/client/000startup/settings.coffee
+++ b/client/000startup/settings.coffee
@@ -17,6 +17,8 @@ settings.WIKI_HOST = server.wikiHost ? 'https://wiki.codexian.us'
 # hunt year, used to make wiki links
 settings.HUNT_YEAR = server.huntYear ? 2014
 
+settings.TEAM_NAME = server.teamName ? 'Codex'
+
 # -- Performance settings --
 
 # make fewer people subscribe to ringhunters chat.

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -182,7 +182,7 @@ Template.blackboard.onRendered ->
   ss.activate(ss.targets[0]) if ss.targets.length
   ss.process()
   #  page title
-  $("title").text("Codex Puzzle Blackboard")
+  $("title").text("#{settings.TEAM_NAME} Puzzle Blackboard")
   # affix side menu
   # XXX disabled because it doesn't play nice with narrow screens
   #$("#bb-sidebar > .bb-sidenav").affix()

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -45,6 +45,8 @@ Template.registerHelper 'linkify', (contents) ->
 Template.registerHelper 'compactHeader', () ->
   (Session.equals 'currentPage', 'chat')
 
+Template.registerHelper 'teamName', -> settings.TEAM_NAME
+
 # subscribe to the all-names feed all the time
 Meteor.subscribe 'all-names'
 # subscribe to all nicks all the time

--- a/quip.html
+++ b/quip.html
@@ -6,9 +6,9 @@
   <form class="bb-add-new-quip">
   <fieldset>
     <span class="help-block">
-Give us a fun way for our duty officer to answer the Codex phone when HQ calls.
+Give us a fun way for our duty officer to answer the {{teamName}} phone when HQ calls.
     </span>
-    <textarea placeholder="Hello, this is Codex…" rows="3"></textarea><br/>
+    <textarea placeholder="Hello, this is {{teamName}}…" rows="3"></textarea><br/>
     <button type="submit" class="btn">Submit</button>
   </fieldset>
   </form>


### PR DESCRIPTION
Makes future team splits easier; also helps if someone else wants to run
the blackboard, e.g. for a non-MIT hunt