### PR TITLE
Make hubot observe load nothing initially

### DIFF
--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -305,6 +305,7 @@ if Meteor.isServer
     M._ensureIndex {to:1, room_name:1, timestamp:-1}, {}
     M._ensureIndex {nick:1, room_name:1, timestamp:-1}, {}
     M._ensureIndex {room_name:1, timestamp:-1}, {}
+    M._ensureIndex {timestamp: 1}, {}
   # watch messages collection and set the followup field as appropriate
   # (followup field should already be set properly when the field is
   #  archived into the OldMessages collection)

--- a/server/hubot.coffee
+++ b/server/hubot.coffee
@@ -184,7 +184,7 @@ Meteor.startup ->
   Meteor.setInterval keepalive, 30*1000 # every 30s refresh presence
   # listen to the chat room, ignoring messages sent before we startup
   startup = true
-  model.Messages.find({}).observeChanges
+  model.Messages.find(timestamp: $gt: model.UTCNow()).observeChanges
     added: (id, msg) ->
       return if startup
       return if msg.bot_ignore


### PR DESCRIPTION
Add an index to Messages and use it to make the initial query return nothing so that startup can be faster.
Should help with cjb#119