### PR TITLE
Empty callin table entry spans all columns

### DIFF
--- a/callins.html
+++ b/callins.html
@@ -27,7 +27,7 @@
       {{#each callins}}
         {{> callin_row }}
       {{else}}
-      <tr><td colspan="5">
+      <tr><td colspan="6">
         No answers in the call-in queue.
       </td></tr>
       {{/each}}


### PR DESCRIPTION
For some reason on only spanned 5 of the 6.